### PR TITLE
Reap older assessments every time we create a new one

### DIFF
--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -1,4 +1,12 @@
+require 'time'
+
 class Assessment < FormResponses
+  def initialize(constructor = nil)
+    super(constructor)
+    self['_type'] = 'assessment'
+    self['date_created'] = Time.now.utc.iso8601
+  end
+
   def add_evidence(evidence)
     evidence_id_list << evidence.id
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,5 +26,10 @@ module MyApp
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+
+    config.number_of_assessments_to_keep = 3
+    config.action_dispatch.rescue_responses.merge!(
+      'AssessmentsController::FormResponsesNotFound' => :not_found
+    )
   end
 end


### PR DESCRIPTION
This is mostly FYI, though if you somehow have time before I'm back, feel free to write some tests to complete this work!

What's happening here:
 - we're limited on session size, so we have to have some strategy for limiting the amount of data we keep in there
 - eventually, storing stuff in the database would give us more freedom to keep more
 - the number of assessments to keep is configurable, we  could do some experiments to find out whether we could increase this a bit
 - as part of this, I've made sure we're generating 404's where appropriate, because data no longer being at the expected URI is now a more common occurrence!

WIP - needs tests

PS it's only going to reap assessments that have a date, so you might want to clear your cookies if you're trying this out :-)