### PR TITLE
Ignore tmp, db and log directories when pushing to PaaS

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,0 +1,4 @@
+tmp
+log
+db
+


### PR DESCRIPTION
Prevent local directories that are unwanted on the PaaS from getting pushed.