### PR TITLE
Fix 'add evidence' flow

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ group :development, :test do
   gem 'capybara'
   gem 'geckodriver-helper'
   gem 'pry-rescue'
+  gem 'rails-controller-testing'
   gem 'rspec-rails'
   gem 'selenium-webdriver'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,6 +133,10 @@ GEM
       bundler (>= 1.3.0)
       railties (= 5.2.3)
       sprockets-rails (>= 2.0.0)
+    rails-controller-testing (1.0.4)
+      actionpack (>= 5.0.1.x)
+      actionview (>= 5.0.1.x)
+      activesupport (>= 5.0.1.x)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -247,6 +251,7 @@ DEPENDENCIES
   pry-rescue
   puma (~> 3.11)
   rails (~> 5.2.3)
+  rails-controller-testing
   rspec-rails
   rubocop-performance
   sass-rails (~> 5.0)

--- a/app/controllers/evidence_questions_controller.rb
+++ b/app/controllers/evidence_questions_controller.rb
@@ -3,7 +3,6 @@ class EvidenceQuestionsController < AssessmentsController
   def choose_evidence
     if request.post? && !params[:evidence_type] && params[:evidence_type_other].blank?
       @errors[:evidence_type] = 'You must choose a piece of evidence'
-      return choose_evidence_get
     end
 
     if request.get? || !@errors.empty?

--- a/spec/controllers/evidence_questions_spec.rb
+++ b/spec/controllers/evidence_questions_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+# probably mostly testing error cases here – successful flows have system tests?
+
+describe EvidenceQuestionsController, type: :controller do
+  describe "POST choose_evidence" do
+    it "shows errors if nothing posted" do
+      post :choose_evidence, params: { assessment_id: 'some-assessment-id', evidence_id: 'new' }
+      expect(assigns(:errors)).not_to be_empty
+    end
+  end
+end


### PR DESCRIPTION
We left an old method call in there

* Added a controller test to catch this: controller tests seem to be vaguely deprecated, but a request test for this would make the test more brittle/complicated. Other GDS Rails apps seem to make use of these, so it's probably ok.

https://trello.com/c/reemF8gj/159-checks-on-identity-questions-in-tool