### PR TITLE
Specify exact Ruby version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6-alpine
+FROM ruby:2.6.2-alpine
 RUN apk update
 RUN apk upgrade
 


### PR DESCRIPTION
Specify exact Ruby version in Dockerfile, otherwise our build breaks when the version of Ruby in the  container is no longer the same as the version given in the Gemfile.

Laurence, lemme know if this helps :-)