### PR TITLE
Checkboxes questions should be stored as a simple list

### DIFF
--- a/app/controllers/activity_questions_controller.rb
+++ b/app/controllers/activity_questions_controller.rb
@@ -44,7 +44,7 @@ class ActivityQuestionsController < AssessmentsController
 
     assessment = find_assessment
     assessment['identity_with_organisation_proved'] = params[:identity_with_organisation_proved]
-    assessment['org_check_method'] = params[:org_check_method]
+    assessment['org_check_method'] = checkboxes_params_to_list(params[:org_check_method])
     save(assessment)
 
     if params[:identity_with_organisation_proved] == 'no'

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,4 +8,9 @@ private
   def setup_error_messages
     @errors = DesignSystem::Errors.new
   end
+
+  def checkboxes_params_to_list(checkboxes_response_hash)
+    # not sure why this is needed exactly - TODO investigate - this method is documentation as much as anything
+    checkboxes_response_hash.keys
+  end
 end

--- a/app/controllers/fraud_questions_controller.rb
+++ b/app/controllers/fraud_questions_controller.rb
@@ -42,7 +42,7 @@ class FraudQuestionsController < AssessmentsController
     end
 
     assessment = find_assessment
-    assessment['check_identity_not_stolen_or_used_fraudulently'] = params[:check_identity_not_stolen_or_used_fraudulently]
+    assessment['check_identity_not_stolen_or_used_fraudulently'] = checkboxes_params_to_list(params[:check_identity_not_stolen_or_used_fraudulently])
     save(assessment)
 
     if params[:check_identity_not_stolen_or_used_fraudulently] == []


### PR DESCRIPTION
We were getting a hash with key => key ie identical keys and values, which is not what we want.

Have not implemented any tests for this: we aren't testing anything about how we store the data, at the moment. This would probably be covered (at least) by tests on the score calculation, which will need to use this data.