### PR TITLE
Refactor models again

### DIFF
--- a/app/controllers/activity_questions_controller.rb
+++ b/app/controllers/activity_questions_controller.rb
@@ -18,7 +18,7 @@ class ActivityQuestionsController < AssessmentsController
     end
 
     assessment = find_assessment
-    assessment['identity_exists_over_time'] = params[:identity_exists_over_time]
+    assessment.identity_exists_over_time = params[:identity_exists_over_time]
     save(assessment)
   end
 
@@ -43,8 +43,8 @@ class ActivityQuestionsController < AssessmentsController
     end
 
     assessment = find_assessment
-    assessment['identity_with_organisation_proved'] = params[:identity_with_organisation_proved]
-    assessment['org_check_method'] = checkboxes_params_to_list(params[:org_check_method])
+    assessment.identity_with_organisation_proved = params[:identity_with_organisation_proved]
+    assessment.org_check_method = checkboxes_params_to_list(params[:org_check_method])
     save(assessment)
 
     if params[:identity_with_organisation_proved] == 'no'
@@ -69,7 +69,7 @@ class ActivityQuestionsController < AssessmentsController
     end
 
     assessment = find_assessment
-    assessment['org_activity_found'] = params[:org_activity_found]
+    assessment.org_activity_found = params[:org_activity_found]
     save(assessment)
 
     if params[:org_activity_found] == 'no'
@@ -94,7 +94,7 @@ class ActivityQuestionsController < AssessmentsController
     end
 
     assessment = find_assessment
-    assessment['activity_time_period'] = params[:activity_time_period]
+    assessment.activity_time_period = params[:activity_time_period]
     save(assessment)
 
     redirect_to action: 'activity_result_get'

--- a/app/controllers/activity_questions_controller.rb
+++ b/app/controllers/activity_questions_controller.rb
@@ -18,7 +18,7 @@ class ActivityQuestionsController < AssessmentsController
     end
 
     assessment = find_assessment
-    assessment.identity_exists_over_time = params[:identity_exists_over_time]
+    assessment.attributes = params.permit(:identity_exists_over_time)
     save(assessment)
   end
 
@@ -69,7 +69,7 @@ class ActivityQuestionsController < AssessmentsController
     end
 
     assessment = find_assessment
-    assessment.org_activity_found = params[:org_activity_found]
+    assessment.attributes = params.permit(:org_activity_found)
     save(assessment)
 
     if params[:org_activity_found] == 'no'
@@ -94,7 +94,7 @@ class ActivityQuestionsController < AssessmentsController
     end
 
     assessment = find_assessment
-    assessment.activity_time_period = params[:activity_time_period]
+    assessment.attributes = params.permit(:activity_time_period)
     save(assessment)
 
     redirect_to action: 'activity_result_get'

--- a/app/controllers/assessment_questions_controller.rb
+++ b/app/controllers/assessment_questions_controller.rb
@@ -16,7 +16,7 @@ class AssessmentQuestionsController < AssessmentsController
     assessment.attributes = params.permit(:confidence_level_required)
     save(assessment)
 
-    if params[:confidence_level_required] == "none"
+    if assessment.confidence_level_required == "none"
       redirect_to controller: 'assessment_questions', action: 'no_risk'
     else
       redirect_to controller: 'assessments', action: 'overview'

--- a/app/controllers/assessment_questions_controller.rb
+++ b/app/controllers/assessment_questions_controller.rb
@@ -13,7 +13,7 @@ class AssessmentQuestionsController < AssessmentsController
     end
 
     assessment = find_assessment
-    assessment.confidence_level_required = params[:confidence_level_required]
+    assessment.attributes = params.permit(:confidence_level_required)
     save(assessment)
 
     if params[:confidence_level_required] == "none"

--- a/app/controllers/assessment_questions_controller.rb
+++ b/app/controllers/assessment_questions_controller.rb
@@ -13,7 +13,7 @@ class AssessmentQuestionsController < AssessmentsController
     end
 
     assessment = find_assessment
-    assessment['confidence_level_required'] = params[:confidence_level_required]
+    assessment.confidence_level_required = params[:confidence_level_required]
     save(assessment)
 
     if params[:confidence_level_required] == "none"

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -20,7 +20,7 @@ class AssessmentsController < ApplicationController
       id = params[:evidence_id]
       # note: evidence is created in AssessmentQuestionsController::choose_evidence_post
       assessment = find_assessment
-      if !assessment['evidence'].delete(id).nil?
+      if !assessment.evidence_id_list.delete(id).nil?
         save(assessment)
         delete(Evidence, id)
       end
@@ -53,14 +53,14 @@ private
   end
 
   def save(form_responses)
-    ((session[:form_responses] ||= Hash.new)[form_responses.class.name] ||= Hash.new)[form_responses[:id]] = form_responses
+    ((session[:form_responses] ||= Hash.new)[form_responses.class.name] ||= Hash.new)[form_responses.id] = form_responses.serializable_hash
   end
 
   def delete_assessment(assessment)
     assessment.evidence_id_list.each do |evidence_id|
       delete(Evidence, evidence_id)
     end
-    delete(Assessment, assessment['id'])
+    delete(Assessment, assessment.id)
   end
 
   def delete(model_class, id)
@@ -72,7 +72,7 @@ private
   end
 
   def reap_old_assessments
-    assessments_sorted_by_date = all_assessments.sort_by { |assessment| assessment["date_created"] }
+    assessments_sorted_by_date = all_assessments.sort_by(&:date_created)
     all_but_most_recent = assessments_sorted_by_date[0..-(Rails.configuration.number_of_assessments_to_keep + 1)]
     if !all_but_most_recent.nil?
       all_but_most_recent.each do |assessment|

--- a/app/controllers/evidence_questions_controller.rb
+++ b/app/controllers/evidence_questions_controller.rb
@@ -26,8 +26,8 @@ class EvidenceQuestionsController < AssessmentsController
       params[:evidence_type_other] = nil
     end
 
-    evidence['evidence_type'] = params[:evidence_type]
-    evidence['evidence_type_other'] = params[:evidence_type_other]
+    evidence.evidence_type = params[:evidence_type]
+    evidence.evidence_type_other = params[:evidence_type_other]
     save(evidence)
 
     redirect_to controller: 'assessments', action: 'overview'

--- a/app/controllers/evidence_questions_controller.rb
+++ b/app/controllers/evidence_questions_controller.rb
@@ -26,8 +26,7 @@ class EvidenceQuestionsController < AssessmentsController
       params[:evidence_type_other] = nil
     end
 
-    evidence.evidence_type = params[:evidence_type]
-    evidence.evidence_type_other = params[:evidence_type_other]
+    evidence.attributes = params.permit(:evidence_type, :evidence_type_other)
     save(evidence)
 
     redirect_to controller: 'assessments', action: 'overview'

--- a/app/controllers/fraud_questions_controller.rb
+++ b/app/controllers/fraud_questions_controller.rb
@@ -21,7 +21,7 @@ class FraudQuestionsController < AssessmentsController
     end
 
     assessment = find_assessment
-    assessment.identity_been_stolen_or_used_fraudulently = params[:identity_been_stolen_or_used_fraudulently]
+    assessment.attributes = params.permit(:identity_been_stolen_or_used_fraudulently)
     save(assessment)
   end
 
@@ -70,7 +70,7 @@ class FraudQuestionsController < AssessmentsController
     end
 
     assessment = find_assessment
-    assessment.counter_fraud_data_sources = params[:counter_fraud_data_sources]
+    assessment.attributes = params.permit(:counter_fraud_data_sources)
     save(assessment)
 
 
@@ -95,7 +95,7 @@ class FraudQuestionsController < AssessmentsController
     end
 
     assessment = find_assessment
-    assessment.idependent_counter_fraud_sources = params[:idependent_counter_fraud_sources]
+    assessment.attributes = params.permit(:idependent_counter_fraud_sources)
     save(assessment)
 
     redirect_to action: 'fraud_result_get'

--- a/app/controllers/fraud_questions_controller.rb
+++ b/app/controllers/fraud_questions_controller.rb
@@ -21,7 +21,7 @@ class FraudQuestionsController < AssessmentsController
     end
 
     assessment = find_assessment
-    assessment['identity_been_stolen_or_used_fraudulently'] = params[:identity_been_stolen_or_used_fraudulently]
+    assessment.identity_been_stolen_or_used_fraudulently = params[:identity_been_stolen_or_used_fraudulently]
     save(assessment)
   end
 
@@ -45,10 +45,10 @@ class FraudQuestionsController < AssessmentsController
     end
 
     assessment = find_assessment
-    assessment['check_identity_not_stolen_or_used_fraudulently'] = checkboxes_params_to_list(params[:check_identity_not_stolen_or_used_fraudulently])
+    assessment.check_identity_not_stolen_or_used_fraudulently = checkboxes_params_to_list(params[:check_identity_not_stolen_or_used_fraudulently])
     save(assessment)
 
-    all_options_selected = Set.new(checkboxes_params_to_list(params[:check_identity_not_stolen_or_used_fraudulently])) == Set.new(@form.lists['check_identity_not_stolen_or_used_fraudulently'].items.keys) - Set['none']
+    all_options_selected = Set.new(assessment.check_identity_not_stolen_or_used_fraudulently) == Set.new(@form.lists['check_identity_not_stolen_or_used_fraudulently'].items.keys) - Set['none']
     if all_options_selected
       redirect_to action: 'fraud_2'
     else
@@ -70,7 +70,7 @@ class FraudQuestionsController < AssessmentsController
     end
 
     assessment = find_assessment
-    assessment['counter_fraud_data_sources'] = params[:counter_fraud_data_sources]
+    assessment.counter_fraud_data_sources = params[:counter_fraud_data_sources]
     save(assessment)
 
 
@@ -95,7 +95,7 @@ class FraudQuestionsController < AssessmentsController
     end
 
     assessment = find_assessment
-    assessment['idependent_counter_fraud_sources'] = params[:idependent_counter_fraud_sources]
+    assessment.idependent_counter_fraud_sources = params[:idependent_counter_fraud_sources]
     save(assessment)
 
     redirect_to action: 'fraud_result_get'

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -1,16 +1,22 @@
 require 'time'
 
 class Assessment < FormResponses
-  def initialize(constructor = nil)
-    super(constructor)
-    self['date_created'] = Time.now.utc.iso8601
+  ATTRS = %i[id date_created confidence_level_required
+             evidence_id_list
+             identity_exists_over_time identity_with_organisation_proved org_check_method org_activity_found activity_time_period
+             identity_been_stolen_or_used_fraudulently check_identity_not_stolen_or_used_fraudulently counter_fraud_data_sources idependent_counter_fraud_sources].freeze
+  attr_accessor(*ATTRS)
+
+  def initialize(attributes = {})
+    super
+    self.date_created = Time.now.utc.iso8601 if !self.date_created
   end
 
   def add_evidence(evidence)
-    evidence_id_list << evidence.id
+    self.evidence_id_list << evidence.id
   end
 
   def evidence_id_list
-    self['evidence'] ||= Array.new
+    @evidence_id_list ||= Array.new
   end
 end

--- a/app/models/evidence.rb
+++ b/app/models/evidence.rb
@@ -1,5 +1,8 @@
 class Evidence < FormResponses
+  ATTRS = %i[id evidence_type evidence_type_other].freeze
+  attr_accessor(*ATTRS)
+
   def name
-    self['evidence_type'] || self['evidence_type_other']
+    self.evidence_type || self.evidence_type_other
   end
 end

--- a/app/models/form_responses.rb
+++ b/app/models/form_responses.rb
@@ -1,6 +1,14 @@
+# Base class for (non-ActiveRecord) models providing serialization and attribute access
 class FormResponses
   include ActiveModel::Model
   include ActiveModel::Serialization
+
+  # Derived classes should provide ATTRS (a list of field name symbols), this is
+  # necessary for our serialization process (see #attributes).
+  #
+  # Background https://guides.rubyonrails.org/active_model_basics.html
+  #            https://api.rubyonrails.org/classes/ActiveModel/Model.html
+  #            https://api.rubyonrails.org/classes/ActiveModel/Serialization.html
 
   ATTRS = [:id].freeze
   attr_accessor(*ATTRS)
@@ -17,4 +25,6 @@ class FormResponses
     self.class::ATTRS.each { |attribute| all[attribute] = nil }
     all
   end
+
+  # attributes= is handled for us by ActiveModel::Model
 end

--- a/app/models/form_responses.rb
+++ b/app/models/form_responses.rb
@@ -21,9 +21,8 @@ class FormResponses
   end
 
   def attributes
-    all = Hash.new
-    self.class::ATTRS.each { |attribute| all[attribute] = nil }
-    all
+    # { field_name_1 => nil, field_name_2 => nil, ... }
+    Hash[self.class::ATTRS.map { |attribute| [attribute] }]
   end
 
   # attributes= is handled for us by ActiveModel::Model

--- a/app/models/form_responses.rb
+++ b/app/models/form_responses.rb
@@ -1,10 +1,20 @@
-class FormResponses < ActiveSupport::HashWithIndifferentAccess
-  def initialize(constructor = nil)
-    self[:id] = SecureRandom.uuid if constructor.nil?
-    super(constructor)
+class FormResponses
+  include ActiveModel::Model
+  include ActiveModel::Serialization
+
+  ATTRS = [:id].freeze
+  attr_accessor(*ATTRS)
+
+  def initialize(attributes = {})
+    # filter out invalid / no-longer valid fields from data (eg coming from the session)
+    attributes.keep_if { |k, _| self.class::ATTRS.include? k.to_sym }
+    super
+    self.id = SecureRandom.uuid if !self.id
   end
 
-  def id
-    self[:id]
+  def attributes
+    all = Hash.new
+    self.class::ATTRS.each { |attribute| all[attribute] = nil }
+    all
   end
 end

--- a/app/views/assessments/_remove-evidence.erb
+++ b/app/views/assessments/_remove-evidence.erb
@@ -4,7 +4,7 @@
       Are you sure you want to remove '<%= @remove_evidence.name %>'?
     </h2>
     <div class="govuk-error-summary__body">
-      <%= form_tag("evidence/#{@remove_evidence['id']}/remove", method: "post") do %>
+      <%= form_tag("evidence/#{@remove_evidence.id}/remove", method: "post") do %>
         <%= hidden_field_tag 'authenticity_token', form_authenticity_token %> <%# form_tag alone appears to generate wrong authenticity token when submitting to another controller? %>
         <%= submit_tag 'Yes, remove', name: 'confirmation', class: 'govuk-button govuk-button--warning' %>
         <a href="overview" class="cancel">Cancel</a>

--- a/app/views/assessments/overview.html.erb
+++ b/app/views/assessments/overview.html.erb
@@ -22,7 +22,7 @@
       <tbody class="govuk-table__body">
         <tr class="govuk-table__row">
           <td class="govuk-table__cell" scope="row">What level of confidence you need</td>
-          <td class="govuk-table__cell"><%= @assessment['confidence_level_required'] %></td>
+          <td class="govuk-table__cell"><%= @assessment.confidence_level_required %></td>
           <td class="govuk-table__cell edit"><a href="your-risk">Change</a></td>
         </tr>
       </tbody>
@@ -30,7 +30,7 @@
 
     <h2 class="govuk-heading-m govuk-!-margin-bottom-0 visually-hidden">Evidence you collect</h2>
 
-    <% if @assessment['evidence'].blank? %>
+    <% if @evidence_list.empty? %>
       <table class="govuk-table govuk-!-margin-bottom-7 govuk-!-margin-top-0">
         <thead class="govuk-table__head">
           <tr class="govuk-table__row">

--- a/spec/system/new_assessment_flow_spec.rb
+++ b/spec/system/new_assessment_flow_spec.rb
@@ -13,4 +13,21 @@ RSpec.feature 'New assessment flow', type: :system do
     click_button 'Continue'
     then_i_am_told_to_choose_a_confidence_level
   end
+
+  scenario 'Choose the lowest confidence level' do
+    when_i_start_a_new_assessment
+    and_i_choose_the_lowest_confidence_level
+    then_i_see_the_information_screen
+    then_i_see_the_overview_screen
+  end
+end
+
+def and_i_choose_the_lowest_confidence_level
+  choose 'None'
+  click_button 'Continue'
+end
+
+def then_i_see_the_information_screen
+  expect(page).to have_content 'You might not need to check a user’s identity'
+  click_button 'Continue'
 end


### PR DESCRIPTION
This is a suggestion based on a chunk of research, trying to get our app into a more idiomatically "Rails-like" state before we add too much more code. I'm really hoping this would (if we think it makes sense to land it) be the last time we faff around with the basic structure :-)

TLDR: our base model class `FormResponses` would now inherit traits from `ActiveModel::Model` rather than inheriting from `HashWithIndifferentAccess`.

The idea here for our models to look like actual Rails models. If we were to one day substitute ActiveRecord models for our own, there would be much less code to change, because these models should support most of the same ways to access their attributes.

For example, you can test `evidence.confidence_level_required == 'none'` rather than using array access syntax.

Here are the references I've been using:

https://guides.rubyonrails.org/active_model_basics.html
https://api.rubyonrails.org/classes/ActiveModel/Model.html
https://api.rubyonrails.org/classes/ActiveModel/Serialization.html
https://yehudakatz.com/2010/01/10/activemodel-make-any-ruby-object-feel-like-activerecord/

See you what you think, anyway.