### PR TITLE
Fix typo in model member name

### DIFF
--- a/app/controllers/fraud_questions_controller.rb
+++ b/app/controllers/fraud_questions_controller.rb
@@ -83,8 +83,8 @@ class FraudQuestionsController < AssessmentsController
 
   def fraud_3
     if request.post?
-      if !params[:idependent_counter_fraud_sources]
-        @errors[:idependent_counter_fraud_sources] = 'You must answer the question'
+      if !params[:independent_counter_fraud_sources]
+        @errors[:independent_counter_fraud_sources] = 'You must answer the question'
       end
     end
 
@@ -95,7 +95,7 @@ class FraudQuestionsController < AssessmentsController
     end
 
     assessment = find_assessment
-    assessment.attributes = params.permit(:idependent_counter_fraud_sources)
+    assessment.attributes = params.permit(:independent_counter_fraud_sources)
     save(assessment)
 
     redirect_to action: 'fraud_result_get'

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -4,7 +4,7 @@ class Assessment < FormResponses
   ATTRS = %i[id date_created confidence_level_required
              evidence_id_list
              identity_exists_over_time identity_with_organisation_proved org_check_method org_activity_found activity_time_period
-             identity_been_stolen_or_used_fraudulently check_identity_not_stolen_or_used_fraudulently counter_fraud_data_sources idependent_counter_fraud_sources].freeze
+             identity_been_stolen_or_used_fraudulently check_identity_not_stolen_or_used_fraudulently counter_fraud_data_sources independent_counter_fraud_sources].freeze
   attr_accessor(*ATTRS)
 
   def initialize(attributes = {})

--- a/app/views/assessments/fraud/fraud-3.html.erb
+++ b/app/views/assessments/fraud/fraud-3.html.erb
@@ -16,7 +16,7 @@
           </ul>
           <div class="govuk-radios">
           <% @shared.lists['yes_no'].items.each do |value, item| %>
-            <%= render 'shared/radio_item', name: :idependent_counter_fraud_sources, item: item %>
+            <%= render 'shared/radio_item', name: :independent_counter_fraud_sources, item: item %>
           <% end %>
           </div>
         </fieldset>
@@ -24,4 +24,4 @@
       <%= submit_tag("Continue", class: "govuk-button") %>
     <% end %>
   </div>
-</div> 
+</div>


### PR DESCRIPTION
Just fixing that typo "idependent_counter_fraud_sources"