### PR TITLE
Remove the link from errors to just display as text

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -21,7 +21,7 @@ $govuk-fonts-path: "govuk-frontend/assets/fonts/";
   vertical-align: baseline;  // align with cancel button if present
 }
 
-.govuk-error-summary a {
-  display: inline-block;
-  margin: 10px 0 0 15px;
+.govuk-error-summary__list {
+  color: #b10e1e;
+  font-weight: 700;
 }

--- a/app/views/shared/_errors.html.erb
+++ b/app/views/shared/_errors.html.erb
@@ -7,7 +7,7 @@
       <ul class="govuk-list govuk-error-summary__list">
         <% @errors.each do |field_id, message| %>
           <li>
-            <%= link_to "#{message}" , "##{field_id}" %>
+            <%= message %>
           </li>
         <% end %>
       </ul>


### PR DESCRIPTION
Removed the link from error message so now just displays the text. Also fixes the indentations issue of error message.