### PR TITLE
Re-introduce access control

### DIFF
--- a/app/models/assessment_session_access.rb
+++ b/app/models/assessment_session_access.rb
@@ -1,0 +1,3 @@
+class AssessmentSessionAccess < ApplicationRecord
+  belongs_to :assessment
+end

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -7,7 +7,7 @@ ActiveSupport::Inflector.inflections(:en) do |inflect|
   #inflect.plural /^(ox)$/i, '\1en'
   #inflect.singular /^(ox)en/i, '\1'
   #inflect.irregular 'person', 'people'
-  inflect.uncountable %w(evidence)
+  inflect.uncountable %w(evidence assessment_session_access)
 end
 
 # These inflection rules are supported but not enabled by default:

--- a/db/migrate/20190626144326_create_assessment_session_access.rb
+++ b/db/migrate/20190626144326_create_assessment_session_access.rb
@@ -1,0 +1,9 @@
+class CreateAssessmentSessionAccess < ActiveRecord::Migration[5.2]
+  def change
+    create_table :assessment_session_access do |t|
+      t.references :assessment, foreign_key: true
+      t.string :session_id, null: false
+    end
+    add_index :assessment_session_access, :session_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_25_120409) do
+ActiveRecord::Schema.define(version: 2019_06_26_144326) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "assessment_session_access", force: :cascade do |t|
+    t.bigint "assessment_id"
+    t.string "session_id", null: false
+    t.index ["assessment_id"], name: "index_assessment_session_access_on_assessment_id"
+    t.index ["session_id"], name: "index_assessment_session_access_on_session_id"
+  end
 
   create_table "assessments", force: :cascade do |t|
     t.string "confidence_level_required"
@@ -84,4 +91,5 @@ ActiveRecord::Schema.define(version: 2019_06_25_120409) do
     t.index ["assessment_id"], name: "index_evidence_on_assessment_id"
   end
 
+  add_foreign_key "assessment_session_access", "assessments"
 end

--- a/spec/system/access_control_spec.rb
+++ b/spec/system/access_control_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+require_relative "steps_helper"
+
+RSpec.feature 'Access control for assessments and related data', type: :system do
+  scenario 'Load up another an assessment created by another user' do
+    when_i_start_a_new_assessment
+    and_i_choose_a_regular_confidence_level
+    and_i_record_the_assessment_uri
+    and_i_start_a_new_session
+    then_i_cannot_see_that_assessment
+  end
+end
+
+def and_i_start_a_new_session
+  Capybara.current_session.reset!
+end
+
+def and_i_record_the_assessment_uri
+  @assessment_uri = current_url
+end
+
+def then_i_cannot_see_that_assessment
+  assert_raises(ActiveRecord::RecordNotFound) do
+    visit @assessment_uri
+  end
+end


### PR DESCRIPTION
* users should only be able to access assessments that they created;
* we have no login system, so we go by a session identifier instead.

https://trello.com/c/W43Pajym/187-use-database-instead-of-session