### PR TITLE
Evidence strength scoring

### DIFF
--- a/app/controllers/evidence_questions_controller.rb
+++ b/app/controllers/evidence_questions_controller.rb
@@ -28,7 +28,17 @@ class EvidenceQuestionsController < AssessmentsController
     evidence.attributes = params.permit(:evidence_type, :evidence_type_other)
     save(evidence)
 
-    redirect_to action: :validity_physical_0, evidence_id: evidence.id
+    if evidence.evidence_type.nil?
+      redirect_to action: :custom_strength, evidence_id: evidence.id
+    else
+      redirect_to action: :validity_physical_0, evidence_id: evidence.id
+    end
+  end
+
+  def custom_strength
+    handle_evidence "assessments/evidence/custom-strength", [:custom_strength] do
+      redirect_to action: 'validity_physical_0'
+    end
   end
 
   def validity_physical_0

--- a/app/helpers/evidence_helper.rb
+++ b/app/helpers/evidence_helper.rb
@@ -7,4 +7,13 @@ module EvidenceHelper
       evidence.evidence_type_other
     end
   end
+
+  def evidence_strength(form, evidence)
+    if evidence.evidence_type
+      item = form.lists['evidence_type'].items[evidence.evidence_type]
+      item.strength
+    else
+      evidence.custom_strength
+    end
+  end
 end

--- a/app/views/assessments/evidence/choose-evidence.html.erb
+++ b/app/views/assessments/evidence/choose-evidence.html.erb
@@ -1,3 +1,4 @@
+<% @title="Add evidence" %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_tag("#{request.fullpath}", method: "post") do %>
@@ -5,6 +6,7 @@
 
         <fieldset class="govuk-fieldset" aria-describedby="confidence-hint" id="confidence_level_required">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+            <div class="govuk-caption-l">Add evidence</div>
             <h1 class="govuk-fieldset__heading">What’s the piece of evidence you collect?</h1>
           </legend>
           <div>

--- a/app/views/assessments/evidence/custom-strength.html.erb
+++ b/app/views/assessments/evidence/custom-strength.html.erb
@@ -1,0 +1,29 @@
+<% @title="Add evidence" %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_tag("#{request.fullpath}", method: "post") do %>
+      <div class="govuk-form-group">
+        <div class="govuk-caption-l">Add evidence</div>
+        <h1 class="govuk-heading-l">Calculate the strength of the <%= evidence_short_name(@form, @evidence) %></h1>
+        <p>
+          Use the guidance to calculate the strength score for <%= evidence_short_name(@form, @evidence) %>.
+        </p>
+        <p>
+          <a href="https://www.gov.uk/government/publications/identity-proofing-and-verification-of-an-individual" target="_blank">Guidance for scoring evidence strength (opens in a new window or tab)</a>
+        </p>
+        <fieldset class="govuk-fieldset" id='authoritative_source_check'>
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+            What’s the strength of this evidence?
+          </legend>
+
+          <div class="govuk-radios">
+            <% @form.lists['custom_strength'].items.each do |value, item| %>
+              <%= render 'shared/radio_item', name: :custom_strength, item: item %>
+            <% end %>
+          </div>
+        </fieldset>
+      </div>
+      <%= submit_tag("Continue", class: "govuk-button") %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/assessments/evidence/result.html.erb
+++ b/app/views/assessments/evidence/result.html.erb
@@ -2,18 +2,15 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">Your score for evidence</h1>
     <p>
-      The <%= evidence_short_name(@form, @evidence) %> has a strength score of XX out of 4.
+      The <%= evidence_short_name(@form, @evidence) %> has a strength score of <%= evidence_strength(@form, @evidence) %> out of 4.
     </p>
 
     <p>
-      The way you check if the armed forces identity card is real has a validity score of YY out of 4.
+      The way you check if the <%= evidence_short_name(@form, @evidence) %>  card is real has a validity score of YY out of 4.
     </p>
 
     <p>
-      To find out why you got these scores, you can <a
-      href="https://www.gov.uk/government/publications/identity-proofing-and-verification-of-an-individual/identity-proofing-and-verification-of-an-individual#strength" target="_blank"
-      >read the guidance about identity proofing and verification <span class="new-tab">(link opens
-      in a new tab)</span></a>.
+      To find out why you got these scores, you can <a href="https://www.gov.uk/government/publications/identity-proofing-and-verification-of-an-individual/identity-proofing-and-verification-of-an-individual#strength" target="_blank">read the guidance about identity proofing and verification <span class="new-tab">(link opens in a new tab)</span></a>.
     </p>
 
     <%= form_tag("#{request.fullpath}", method: "post") do %>

--- a/app/views/assessments/overview.html.erb
+++ b/app/views/assessments/overview.html.erb
@@ -62,8 +62,8 @@
             <tbody class="govuk-table__body">
               <tr class="govuk-table__row">
                 <td class="govuk-table__cell" scope="row">Strength</td>
-                <td class="govuk-table__cell" scope="row">
-                  ??
+                <td class="govuk-table__cell" scope="row" class="evidence-strength">
+                  <%= evidence_strength(@evidence_form, evidence) %>
                 </td>
               </tr>
               <tr class="govuk-table__row">

--- a/config/forms/evidence.yaml
+++ b/config/forms/evidence.yaml
@@ -128,6 +128,17 @@ lists:
         value: local_authority_doc_letter
         strength: 1
 
+  - name: custom_strength
+    items:
+      - text: '1'
+        value: 1
+      - text: '2'
+        value: 2
+      - text: '3'
+        value: 3
+      - text: '4'
+        value: 4
+
   - name: official_templates_update_frequency
     items:
       - text: Every year

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
   get 'assessments/:assessment_id/no-risk', to: 'assessment_questions#no_risk'
 
   match 'assessments/:assessment_id/evidence/:evidence_id/choose-evidence', to: 'evidence_questions#choose_evidence', via: %i[get post]
+  match 'assessments/:assessment_id/evidence/:evidence_id/custom-strength', to: 'evidence_questions#custom_strength', via: %i[get post]
   match 'assessments/:assessment_id/evidence/:evidence_id/validity-physical-0', to: 'evidence_questions#validity_physical_0', via: %i[get post]
   match 'assessments/:assessment_id/evidence/:evidence_id/validity-physical-1a', to: 'evidence_questions#validity_physical_1a', via: %i[get post]
   match 'assessments/:assessment_id/evidence/:evidence_id/validity-physical-1b', to: 'evidence_questions#validity_physical_1b', via: %i[get post]

--- a/db/migrate/20190628150714_add_custom_strength_to_evidence.rb
+++ b/db/migrate/20190628150714_add_custom_strength_to_evidence.rb
@@ -1,0 +1,5 @@
+class AddCustomStrengthToEvidence < ActiveRecord::Migration[5.2]
+  def change
+    add_column :evidence, :custom_strength, :int
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_27_090600) do
+ActiveRecord::Schema.define(version: 2019_06_28_150714) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -92,6 +92,7 @@ ActiveRecord::Schema.define(version: 2019_06_27_090600) do
     t.json "uv_ir_features"
     t.json "crypto_features"
     t.boolean "is_complete", default: false, null: false
+    t.integer "custom_strength"
     t.index ["assessment_id"], name: "index_evidence_on_assessment_id"
   end
 

--- a/spec/system/evidence_steps_helper.rb
+++ b/spec/system/evidence_steps_helper.rb
@@ -1,0 +1,100 @@
+def and_i_add_a_new_piece_of_evidence(evidence_group, evidence_type)
+  @evidence_text = evidence_type
+  click_link 'Add evidence'
+  choose evidence_group
+  choose evidence_type
+  click_button 'Continue'
+end
+
+def and_i_answer_no_to_every_question
+  ['physical features', 'cryptographic security', 'authoritative source', 'cancelled'].each do |question_snippet|
+    expect(page).to have_content question_snippet
+    choose 'No'
+    click_button 'Continue'
+  end
+end
+
+def and_i_answer_yes_to_every_question
+  ['physical features', 'original', 'errors', 'document capture app', 'recognised guidance', 'taught how to tell'].each do |question_snippet|
+    expect(page).to have_content question_snippet
+    choose 'Yes'
+    click_button 'Continue'
+  end
+
+  expect(page).to have_content 'refresh their training'
+  choose 'Every year'
+  click_button 'Continue'
+
+  expect(page).to have_content 'official templates'
+  choose 'Yes'
+  click_button 'Continue'
+
+  expect(page).to have_content 'templates updated'
+  choose 'Every year'
+  click_button 'Continue'
+
+  ['expired', 'intercepted', 'visible security features', 'protects them from being tampered with'].each do |question_snippet|
+    expect(page).to have_content question_snippet
+    choose 'Yes'
+    click_button 'Continue'
+  end
+
+  expect(page).to have_content 'security features'
+  check 'Designs printed using intaglio (raised) ink'
+  check 'Designs that have been laser etched'
+  check 'Watermarks'
+  check 'Security fibres'
+  check "Secondary background ('ghost') images"
+  click_button 'Continue'
+
+  expect(page).to have_content 'consistent throughout'
+  choose 'Yes'
+  click_button 'Continue'
+
+  expect(page).to have_content 'equipment'
+  check 'magnification tool'
+  check 'low angle'
+  check 'Another piece of equipment'
+  check 'A non-specialist light source'
+  click_button 'Continue'
+
+  ['controlled', 'supervised', 'ultraviolet (UV) or infrared (IR)'].each do |question_snippet|
+    expect(page).to have_content question_snippet
+    choose 'Yes'
+    click_button 'Continue'
+  end
+
+  expect(page).to have_content 'UV or IR security features'
+  check 'The paper the document is printed on'
+  check 'The layout and design of the document'
+  check 'Any fluorescent features'
+  click_button 'Continue'
+
+  expect(page).to have_content 'cryptographic security'
+  choose 'Yes'
+  click_button 'Continue'
+
+  expect(page).to have_content 'cryptographic security features'
+  check 'Check the evidence has not expired'
+  check 'Check the digital signature is correct'
+  check 'Check the signing key belongs to the organisation that issued the evidence'
+  check 'Check the signing key is correct for that type of evidence'
+  check 'Check the signing key has not been revoked'
+  click_button 'Continue'
+
+  ['authoritative source', 'cancelled'].each do |question_snippet|
+    expect(page).to have_content question_snippet
+    choose 'Yes'
+    click_button 'Continue'
+  end
+end
+
+def and_i_can_see_that_evidence_in_the_overview(evidence_type)
+  then_i_see_the_overview_screen
+  expect(page).to have_content evidence_type
+end
+
+def then_i_cannot_see_that_evidence_in_the_overview(evidence_type)
+  then_i_see_the_overview_screen
+  expect(page).not_to have_content evidence_type
+end

--- a/spec/system/remove_evidence_flow_spec.rb
+++ b/spec/system/remove_evidence_flow_spec.rb
@@ -1,5 +1,6 @@
 require "rails_helper"
 require_relative "steps_helper"
+require_relative "evidence_steps_helper"
 
 RSpec.feature 'Remove evidence flow', type: :system do
   scenario 'Remove evidence from an assessment' do
@@ -7,23 +8,18 @@ RSpec.feature 'Remove evidence flow', type: :system do
     and_i_choose_a_regular_confidence_level
     and_i_add_a_new_piece_of_evidence('Passport or travel document', 'UK passport')
     and_i_answer_no_to_every_question
-    then_i_get_a_score('XX', 'out of 4')
+    then_i_get_a_score('4', 'out of 4')
     and_i_add_a_new_piece_of_evidence('Certificate', 'Marriage or civil partnership certificate')
     and_i_answer_no_to_every_question
-    then_i_get_a_score('XX', 'out of 4')
+    then_i_get_a_score('2', 'out of 4')
     then_i_remove_that_evidence('UK passport')
     then_i_cannot_see_that_evidence_in_the_overview('UK passport')
     and_i_can_see_that_evidence_in_the_overview('Marriage or civil partnership certificate')
   end
-end
 
-def then_i_remove_that_evidence(evidence_type)
-  container = page.find('.evidence', text: evidence_type)
-  container.click_link 'Remove'
-  click_button 'Yes, remove'
-end
-
-def then_i_cannot_see_that_evidence_in_the_overview(evidence_type)
-  then_i_see_the_overview_screen
-  expect(page).not_to have_content evidence_type
+  def then_i_remove_that_evidence(evidence_type)
+    container = page.find('.evidence', text: evidence_type)
+    container.click_link 'Remove'
+    click_button 'Yes, remove'
+  end
 end


### PR DESCRIPTION
Strength scoring:
* comes straight out of the list of evidence types, except...
* ...when you're assessing 'custom' evidence, and you have to figure it out yourself, and we store that in a new field.
* also had to re-organise the tests a bit because Ruby.