### PR TITLE
Fix evidence tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apk add --update tzdata && \
 
 # Install your app's runtime dependencies in the container
 ENV BUILD_PACKAGES="postgresql-client curl-dev ruby-dev build-base bash" \
-    DEV_PACKAGES="firefox-esr zlib-dev libxml2-dev libxslt-dev tzdata yaml-dev postgresql-dev" \
+    DEV_PACKAGES="firefox-esr zlib-dev libxml2-dev libxslt-dev tzdata yaml-dev postgresql-dev less" \
     RUBY_PACKAGES="ruby-json yaml nodejs"
 
 # Update and install base packages and nokogiri gem that requires a

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe Assessment, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
-end

--- a/spec/models/evidence_spec.rb
+++ b/spec/models/evidence_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe Evidence, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
-end

--- a/spec/system/activity_questions_spec.rb
+++ b/spec/system/activity_questions_spec.rb
@@ -14,15 +14,15 @@ RSpec.feature 'Activity questions', type: :system do
     and_i_respond 'Yes', to_prompt: "Do you check if the interactions you've found are interactions you'd expect users to have?", and_continue: true
     then_i_get_a_score 'XXX', 'out of 4' # TODO scoring!
   end
-end
 
-def and_i_choose_the_activity_link
-  click_link 'activity-edit'
-end
+  def and_i_choose_the_activity_link
+    click_link 'activity-edit'
+  end
 
-def then_i_get_a_score(score, additional_text)
-  expect(page).to have_content "#{score} #{additional_text}"
-  click_button 'Continue'
-  # expect(find('#activity-score')).to have_text score # TODO
-  # expect(find('#activity-edit')).to have_content 'Change' # TODO
+  def then_i_get_a_score(score, additional_text)
+    expect(page).to have_content "#{score} #{additional_text}"
+    click_button 'Continue'
+    # expect(find('#activity-score')).to have_text score # TODO
+    # expect(find('#activity-edit')).to have_content 'Change' # TODO
+  end
 end

--- a/spec/system/add_evidence_flow_spec.rb
+++ b/spec/system/add_evidence_flow_spec.rb
@@ -3,6 +3,8 @@ require_relative "steps_helper"
 require_relative "evidence_steps_helper"
 
 RSpec.feature 'Add evidence flow', type: :system do
+  include EvidenceStepsHelper
+
   scenario 'Add new evidence to an assessment (short version)' do
     when_i_start_a_new_assessment
     and_i_choose_a_regular_confidence_level
@@ -78,14 +80,16 @@ RSpec.feature 'Add evidence flow', type: :system do
     click_button 'Continue'
   end
 
-  def then_i_get_a_score_for_that_evidence(strength, strength_additional_text)
+  def then_i_get_a_score(strength, strength_additional_text)
+    expect(@evidence_text).not_to be_nil
     expect(page).to have_content "strength score of #{strength} #{strength_additional_text}"
     click_button 'Continue'
-    find('th', text: @evidence_text).find(:xpath, "../../../tbody/tr[1]/td[2]").to have_content strength.to_s
+    expect(find('th', text: @evidence_text).find(:xpath, "../../../tbody/tr[1]/td[2]")).to have_content strength.to_s
     # expect(find('???')).to have_content 'Change' # TODO
   end
 
   def and_i_switch_between_evidence_type_to_other(evidence_group, evidence_type, evidence_other_name)
+    @evidence_text = evidence_other_name
     click_link 'Add evidence'
     choose evidence_group
     choose evidence_type
@@ -95,6 +99,7 @@ RSpec.feature 'Add evidence flow', type: :system do
   end
 
   def and_i_switch_between_evidence_type_to_regular(evidence_other_name, evidence_group, evidence_type)
+    @evidence_text = evidence_type
     click_link 'Add evidence'
     choose 'Other'
     fill_in 'evidence_type_other', with: evidence_other_name

--- a/spec/system/add_evidence_flow_spec.rb
+++ b/spec/system/add_evidence_flow_spec.rb
@@ -51,7 +51,7 @@ RSpec.feature 'Add evidence flow', type: :system do
     when_i_start_a_new_assessment
     and_i_choose_a_regular_confidence_level
     and_i_add_a_new_piece_of_evidence('Passport or travel document', 'UK passport')
-    and_i_answer_yes_to_every_question
+    and_i_answer_all_questions_positively
     then_i_get_a_score('4', 'out of 4')
     and_i_can_see_that_evidence_in_the_overview('UK passport')
   end

--- a/spec/system/evidence_steps_helper.rb
+++ b/spec/system/evidence_steps_helper.rb
@@ -1,100 +1,102 @@
-def and_i_add_a_new_piece_of_evidence(evidence_group, evidence_type)
-  @evidence_text = evidence_type
-  click_link 'Add evidence'
-  choose evidence_group
-  choose evidence_type
-  click_button 'Continue'
-end
-
-def and_i_answer_no_to_every_question
-  ['physical features', 'cryptographic security', 'authoritative source', 'cancelled'].each do |question_snippet|
-    expect(page).to have_content question_snippet
-    choose 'No'
+module EvidenceStepsHelper
+  def and_i_add_a_new_piece_of_evidence(evidence_group, evidence_type)
+    @evidence_text = evidence_type
+    click_link 'Add evidence'
+    choose evidence_group
+    choose evidence_type
     click_button 'Continue'
   end
-end
 
-def and_i_answer_yes_to_every_question
-  ['physical features', 'original', 'errors', 'document capture app', 'recognised guidance', 'taught how to tell'].each do |question_snippet|
-    expect(page).to have_content question_snippet
+  def and_i_answer_no_to_every_question
+    ['physical features', 'cryptographic security', 'authoritative source', 'cancelled'].each do |question_snippet|
+      expect(page).to have_content question_snippet
+      choose 'No'
+      click_button 'Continue'
+    end
+  end
+
+  def and_i_answer_yes_to_every_question
+    ['physical features', 'original', 'errors', 'document capture app', 'recognised guidance', 'taught how to tell'].each do |question_snippet|
+      expect(page).to have_content question_snippet
+      choose 'Yes'
+      click_button 'Continue'
+    end
+
+    expect(page).to have_content 'refresh their training'
+    choose 'Every year'
+    click_button 'Continue'
+
+    expect(page).to have_content 'official templates'
     choose 'Yes'
     click_button 'Continue'
-  end
 
-  expect(page).to have_content 'refresh their training'
-  choose 'Every year'
-  click_button 'Continue'
+    expect(page).to have_content 'templates updated'
+    choose 'Every year'
+    click_button 'Continue'
 
-  expect(page).to have_content 'official templates'
-  choose 'Yes'
-  click_button 'Continue'
+    ['expired', 'intercepted', 'visible security features', 'protects them from being tampered with'].each do |question_snippet|
+      expect(page).to have_content question_snippet
+      choose 'Yes'
+      click_button 'Continue'
+    end
 
-  expect(page).to have_content 'templates updated'
-  choose 'Every year'
-  click_button 'Continue'
+    expect(page).to have_content 'security features'
+    check 'Designs printed using intaglio (raised) ink'
+    check 'Designs that have been laser etched'
+    check 'Watermarks'
+    check 'Security fibres'
+    check "Secondary background ('ghost') images"
+    click_button 'Continue'
 
-  ['expired', 'intercepted', 'visible security features', 'protects them from being tampered with'].each do |question_snippet|
-    expect(page).to have_content question_snippet
+    expect(page).to have_content 'consistent throughout'
     choose 'Yes'
     click_button 'Continue'
-  end
 
-  expect(page).to have_content 'security features'
-  check 'Designs printed using intaglio (raised) ink'
-  check 'Designs that have been laser etched'
-  check 'Watermarks'
-  check 'Security fibres'
-  check "Secondary background ('ghost') images"
-  click_button 'Continue'
+    expect(page).to have_content 'equipment'
+    check 'magnification tool'
+    check 'low angle'
+    check 'Another piece of equipment'
+    check 'A non-specialist light source'
+    click_button 'Continue'
 
-  expect(page).to have_content 'consistent throughout'
-  choose 'Yes'
-  click_button 'Continue'
+    ['controlled', 'supervised', 'ultraviolet (UV) or infrared (IR)'].each do |question_snippet|
+      expect(page).to have_content question_snippet
+      choose 'Yes'
+      click_button 'Continue'
+    end
 
-  expect(page).to have_content 'equipment'
-  check 'magnification tool'
-  check 'low angle'
-  check 'Another piece of equipment'
-  check 'A non-specialist light source'
-  click_button 'Continue'
+    expect(page).to have_content 'UV or IR security features'
+    check 'The paper the document is printed on'
+    check 'The layout and design of the document'
+    check 'Any fluorescent features'
+    click_button 'Continue'
 
-  ['controlled', 'supervised', 'ultraviolet (UV) or infrared (IR)'].each do |question_snippet|
-    expect(page).to have_content question_snippet
+    expect(page).to have_content 'cryptographic security'
     choose 'Yes'
     click_button 'Continue'
-  end
 
-  expect(page).to have_content 'UV or IR security features'
-  check 'The paper the document is printed on'
-  check 'The layout and design of the document'
-  check 'Any fluorescent features'
-  click_button 'Continue'
-
-  expect(page).to have_content 'cryptographic security'
-  choose 'Yes'
-  click_button 'Continue'
-
-  expect(page).to have_content 'cryptographic security features'
-  check 'Check the evidence has not expired'
-  check 'Check the digital signature is correct'
-  check 'Check the signing key belongs to the organisation that issued the evidence'
-  check 'Check the signing key is correct for that type of evidence'
-  check 'Check the signing key has not been revoked'
-  click_button 'Continue'
-
-  ['authoritative source', 'cancelled'].each do |question_snippet|
-    expect(page).to have_content question_snippet
-    choose 'Yes'
+    expect(page).to have_content 'cryptographic security features'
+    check 'Check the evidence has not expired'
+    check 'Check the digital signature is correct'
+    check 'Check the signing key belongs to the organisation that issued the evidence'
+    check 'Check the signing key is correct for that type of evidence'
+    check 'Check the signing key has not been revoked'
     click_button 'Continue'
+
+    ['authoritative source', 'cancelled'].each do |question_snippet|
+      expect(page).to have_content question_snippet
+      choose 'Yes'
+      click_button 'Continue'
+    end
   end
-end
 
-def and_i_can_see_that_evidence_in_the_overview(evidence_type)
-  then_i_see_the_overview_screen
-  expect(page).to have_content evidence_type
-end
+  def and_i_can_see_that_evidence_in_the_overview(evidence_type)
+    then_i_see_the_overview_screen
+    expect(page).to have_content evidence_type
+  end
 
-def then_i_cannot_see_that_evidence_in_the_overview(evidence_type)
-  then_i_see_the_overview_screen
-  expect(page).not_to have_content evidence_type
+  def then_i_cannot_see_that_evidence_in_the_overview(evidence_type)
+    then_i_see_the_overview_screen
+    expect(page).not_to have_content evidence_type
+  end
 end

--- a/spec/system/evidence_steps_helper.rb
+++ b/spec/system/evidence_steps_helper.rb
@@ -15,7 +15,7 @@ module EvidenceStepsHelper
     end
   end
 
-  def and_i_answer_yes_to_every_question
+  def and_i_answer_all_questions_positively
     ['physical features', 'original', 'errors', 'document capture app', 'recognised guidance', 'taught how to tell'].each do |question_snippet|
       expect(page).to have_content question_snippet
       choose 'Yes'

--- a/spec/system/fraud_questions_spec.rb
+++ b/spec/system/fraud_questions_spec.rb
@@ -12,9 +12,7 @@ RSpec.feature 'Fraud questions', type: :system do
     and_i_respond 'Yes', to_prompt: 'Are the counter-fraud sources you use independent?', and_continue: true
     then_i_get_a_score 'XXX', 'out of 4' # TODO scoring!
   end
-end
 
-RSpec.feature 'Fraud questions', type: :system do
   scenario 'Fail to do all of the fraud checks' do
     when_i_start_a_new_assessment
     and_i_choose_a_regular_confidence_level
@@ -23,26 +21,26 @@ RSpec.feature 'Fraud questions', type: :system do
     and_i_say_i_do_all_the_fraud_checks(nearly: true)
     then_i_get_a_score 'XXX', 'out of 4' # TODO scoring!
   end
-end
 
-def and_i_choose_the_fraud_link
-  click_link 'fraud-edit'
-end
-
-def and_i_say_i_do_all_the_fraud_checks(nearly: false)
-  check "The person has not had their details stolen (even if those details have not been used fraudulently yet)"
-  check "The person's identity has not been reported as stolen"
-  check "The person is not at a high risk of being impersonated (for example if they’re a ‘politically exposed person’, like a politician or a judge)"
-  check "The person's details do not belong to someone who has died"
-  if !nearly
-    check "The person's details are known by an organisation that should have a record of that person (for example an Electoral Registration Office in a local authority)"
+  def and_i_choose_the_fraud_link
+    click_link 'fraud-edit'
   end
-  click_button 'Continue'
-end
 
-def then_i_get_a_score(score, additional_text)
-  expect(page).to have_content "#{score} #{additional_text}"
-  click_button 'Continue'
-  # expect(find('#fraud-score')).to have_text score # TODO
-  # expect(find('#fraud-edit')).to have_content 'Change' # TODO
+  def and_i_say_i_do_all_the_fraud_checks(nearly: false)
+    check "The person has not had their details stolen (even if those details have not been used fraudulently yet)"
+    check "The person's identity has not been reported as stolen"
+    check "The person is not at a high risk of being impersonated (for example if they’re a ‘politically exposed person’, like a politician or a judge)"
+    check "The person's details do not belong to someone who has died"
+    if !nearly
+      check "The person's details are known by an organisation that should have a record of that person (for example an Electoral Registration Office in a local authority)"
+    end
+    click_button 'Continue'
+  end
+
+  def then_i_get_a_score(score, additional_text)
+    expect(page).to have_content "#{score} #{additional_text}"
+    click_button 'Continue'
+    # expect(find('#fraud-score')).to have_text score # TODO
+    # expect(find('#fraud-edit')).to have_content 'Change' # TODO
+  end
 end

--- a/spec/system/remove_evidence_flow_spec.rb
+++ b/spec/system/remove_evidence_flow_spec.rb
@@ -3,21 +3,27 @@ require_relative "steps_helper"
 require_relative "evidence_steps_helper"
 
 RSpec.feature 'Remove evidence flow', type: :system do
+  include EvidenceStepsHelper
+
   scenario 'Remove evidence from an assessment' do
     when_i_start_a_new_assessment
     and_i_choose_a_regular_confidence_level
     and_i_add_a_new_piece_of_evidence('Passport or travel document', 'UK passport')
     and_i_answer_no_to_every_question
-    then_i_get_a_score('4', 'out of 4')
+    and_i_continue_past_the_result_screen
     and_i_add_a_new_piece_of_evidence('Certificate', 'Marriage or civil partnership certificate')
     and_i_answer_no_to_every_question
-    then_i_get_a_score('2', 'out of 4')
-    then_i_remove_that_evidence('UK passport')
+    and_i_continue_past_the_result_screen
+    and_i_remove_that_evidence('UK passport')
     then_i_cannot_see_that_evidence_in_the_overview('UK passport')
     and_i_can_see_that_evidence_in_the_overview('Marriage or civil partnership certificate')
   end
 
-  def then_i_remove_that_evidence(evidence_type)
+  def and_i_continue_past_the_result_screen
+    click_button 'Continue'
+  end
+
+  def and_i_remove_that_evidence(evidence_type)
     container = page.find('.evidence', text: evidence_type)
     container.click_link 'Remove'
     click_button 'Yes, remove'

--- a/spec/system/verification_questions_spec.rb
+++ b/spec/system/verification_questions_spec.rb
@@ -36,15 +36,15 @@ RSpec.feature 'Verification questions', type: :system do
     and_i_respond '8 or more', to_prompt: 'Do you ask multiple or single choice KBV questions?', and_continue: true
     then_i_get_a_score 'XXX', 'out of 4' # TODO scoring!
   end
-end
 
-def and_i_choose_the_verification_link
-  click_link 'verification-edit'
-end
+  def and_i_choose_the_verification_link
+    click_link 'verification-edit'
+  end
 
-def then_i_get_a_score(score, additional_text)
-  expect(page).to have_content "#{score} #{additional_text}"
-  click_button 'Continue'
-  # expect(find('#verification-score')).to have_text score # TODO
-  # expect(find('#verification-edit')).to have_content 'Change' # TODO
+  def then_i_get_a_score(score, additional_text)
+    expect(page).to have_content "#{score} #{additional_text}"
+    click_button 'Continue'
+    # expect(find('#verification-score')).to have_text score # TODO
+    # expect(find('#verification-edit')).to have_content 'Change' # TODO
+  end
 end


### PR DESCRIPTION
Most of this PR is about removing functions from global scope, except we also:

 - add `less` as a dependency because the `less` in alpine is not GNU less and is broken is some dumb way that breaks `pry-rescue`
 - actually fix the test in `'Add evidence flow'::then_i_get_a_score` (now that method actually gets run!)